### PR TITLE
ARTMXCICH-149/Fix ResourceDocsEditView to restrict access to only resources belonging to the dataset

### DIFF
--- a/ckanext/resource_docs/views.py
+++ b/ckanext/resource_docs/views.py
@@ -20,9 +20,17 @@ class ResourceDocsEditView(MethodView):
             )
 
             pkg_dict = tk.get_action("package_show")({}, {"id": package_id})
-            resource = tk.get_action("resource_show")({}, {"id": resource_id})
 
         except (tk.ObjectNotFound, tk.NotAuthorized):
+            return tk.abort(404, tk._("Resource not found"))
+
+        resource = None
+        for res in pkg_dict.get(u'resources', []):
+            if res["id"] == resource_id:
+                resource = res
+                break
+
+        if not resource:
             return tk.abort(404, tk._("Resource not found"))
 
         try:

--- a/ckanext/resource_docs/views.py
+++ b/ckanext/resource_docs/views.py
@@ -27,11 +27,8 @@ class ResourceDocsEditView(MethodView):
         except (tk.ObjectNotFound, tk.NotAuthorized):
             return tk.abort(404, tk._("Resource not found"))
 
-        resource = None
-        for res in pkg_dict.get(u'resources', []):
-            if res["id"] == resource_id:
-                resource = res
-                break
+        resources = {res["id"]: res for res in pkg_dict.get("resources", [])}
+        resource = resources.get(resource_id)
 
         if not resource:
             return tk.abort(404, tk._("Resource not found"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ckanext-resource-docs"
-version = "0.3.0"
+version = "0.3.1"
 description = "A CKAN extension that lets you attach a flexible, schema-free data dictionary (“resource documentation”) to any resource, not just Datastore-backed ones."
 readme = "README.md"
 authors = [{ name = "Oleksandr Cherniavskiy", email = "mutantsan@gmail.com" }]


### PR DESCRIPTION
Previously, any resource_id could be accessed in `/dataset/resource_docs/<resource_id>` if the user had rights. Now, only resources present in the dataset are retrieved; otherwise a 404 is returned.

Updated the version to 0.4.3 in pyproject.toml